### PR TITLE
feature: Add Login Component scaffold

### DIFF
--- a/template/_templates/component/new/component.ejs
+++ b/template/_templates/component/new/component.ejs
@@ -4,7 +4,7 @@ to: src/components/<%= h.inflection.transform(name, ['undasherize', 'classify'])
 <% const formattedName = h.inflection.transform(name, ['undasherize', 'classify']) -%>
 import React, { FC } from 'react';
 
-import { View } from './View';
+import { Container } from './Container';
 
 interface Props {
   /** prop info */
@@ -22,9 +22,9 @@ export const <%= formattedName %>: FC<Props> = (props = DEFAULT_PROPS) => {
   const { children } = props;
 
   return (
-    <View>
+    <Container>
       {children}
-    </View>
+    </Container>
   );
 };
 

--- a/template/_templates/component/new/stories.ejs
+++ b/template/_templates/component/new/stories.ejs
@@ -5,7 +5,7 @@ to: src/components/<%= h.inflection.transform(name, ['undasherize', 'classify'])
 import { storiesOf } from '@storybook/react-native';
 import React from 'react';
 
-import { <%= formattedName %> } from './component';
+import { <%= formattedName %> } from './<%= formattedName %>';
 
 storiesOf('components/<%= formattedName %>', module).add('Default', () => (
   <<%= formattedName %> />

--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,6 @@
     "test": "jest",
     "test:watch": "jest --changedSince=master --watch",
     "lint": "eslint . --ext .ts,.tsx",
-    "storybook": "storybook start -p 7007",
     "g:component": "hygen component new --name",
     "g:screen": "hygen screen new --name",
     "g:util": "hygen util new --name",

--- a/template/src/components/Button/Button.stories.tsx
+++ b/template/src/components/Button/Button.stories.tsx
@@ -1,0 +1,8 @@
+import { storiesOf } from '@storybook/react-native';
+import React from 'react';
+
+import { Button } from './Button';
+
+storiesOf('components/Button', module).add('Default', () => (
+  <Button label="Button" />
+));

--- a/template/src/components/Button/Button.tsx
+++ b/template/src/components/Button/Button.tsx
@@ -1,0 +1,118 @@
+import React, { FC } from 'react';
+import { ActivityIndicator } from 'react-native';
+import {
+  backgroundColor,
+  color,
+  space,
+  layout,
+  flexbox,
+  borders,
+  BorderProps,
+  ColorProps,
+  SpaceProps,
+  FlexProps,
+  LayoutProps,
+} from 'styled-system';
+import styled from '@emotion/native';
+
+import { Container } from '../Container';
+import { Text } from '../Text';
+import { Touchable } from '../Touchable';
+import { colors } from '../../styles';
+
+interface ButtonProps {
+  /** accessibility label */
+  accessibilityLabel: string;
+  /** disabled button state */
+  disabled?: boolean;
+  /** loading button state */
+  loading?: boolean;
+  /** the text label of the button */
+  label: string;
+  /** the callback to be invoked onPress */
+  onPress: () => void;
+}
+
+type ComponentProps = ButtonProps & BorderProps & ColorProps & SpaceProps & FlexProps & LayoutProps;
+
+const Wrapper = styled(Touchable)`
+  ${color}
+  
+  ${borders}
+  ${space}
+  ${layout}
+  ${flexbox}
+`;
+
+const DisabledWrapper = styled(Container)`
+  ${color}
+  ${borders}
+  ${space}
+  ${layout}
+  ${flexbox}
+`;
+
+const Label = styled(Text)`
+  ${props =>
+    props.disabled &&
+    `
+      color: ${props.theme.colors.gray9};
+    `}
+`;
+
+/**
+ * notes:
+ * - restricting inner text style from being directly configurable to avoid style prop conflicts
+ * - if button is disabled it will not render a touchableOpacity at all
+ */
+export const Button: FC<ComponentProps> = ({
+  accessibilityLabel,
+  label,
+  onPress,
+  disabled,
+  loading,
+  color: componentColor,
+  ...props
+}) =>
+  disabled ? (
+    <DisabledWrapper accessibilityLabel={accessibilityLabel} {...props}>
+      {loading ? <ActivityIndicator /> : <Label disabled>{label}</Label>}
+    </DisabledWrapper>
+  ) : (
+    <Wrapper
+      accessibilityLabel={accessibilityLabel}
+      onPress={loading ? null : onPress}
+      bg={backgroundColor}
+      {...props}
+    >
+      {loading ? <ActivityIndicator /> : <Label color={componentColor}>{label}</Label>}
+    </Wrapper>
+  );
+
+Wrapper.defaultProps = {
+  alignItems: 'center',
+  bg: colors.orange,
+  borderRadius: 40,
+  height: 50,
+  justifyContent: 'center',
+  width: 0.6,
+};
+
+DisabledWrapper.defaultProps = {
+  alignItems: 'center',
+  bg: colors.gray,
+  borderRadius: 40,
+  height: 50,
+  justifyContent: 'center',
+  width: 0.6,
+};
+
+Label.defaultProps = {
+  color: colors.white,
+  fontWeight: 'bold',
+  fontSize: 2,
+};
+
+Button.defaultProps = {
+  disabled: false,
+};

--- a/template/src/components/Button/Button.tsx
+++ b/template/src/components/Button/Button.tsx
@@ -61,7 +61,8 @@ export const Button: FC<ComponentProps> = ({
       height={50}
       width={0.6}
       accessibilityLabel={accessibilityLabel}
-      onPress={disabled ? null : onPressAction}
+      onPress={onPressAction}
+      disabled={disabled}
       {...props}
     >
       {loading ? (

--- a/template/src/components/Button/Button.tsx
+++ b/template/src/components/Button/Button.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { ActivityIndicator } from 'react-native';
 import {
   backgroundColor,
+  borderColor,
   color,
   space,
   layout,
@@ -35,31 +36,6 @@ interface ButtonProps {
 
 type ComponentProps = ButtonProps & BorderProps & ColorProps & SpaceProps & FlexProps & LayoutProps;
 
-const Wrapper = styled(Touchable)`
-  ${color}
-  
-  ${borders}
-  ${space}
-  ${layout}
-  ${flexbox}
-`;
-
-const DisabledWrapper = styled(Container)`
-  ${color}
-  ${borders}
-  ${space}
-  ${layout}
-  ${flexbox}
-`;
-
-const Label = styled(Text)`
-  ${props =>
-    props.disabled &&
-    `
-      color: ${props.theme.colors.gray9};
-    `}
-`;
-
 /**
  * notes:
  * - restricting inner text style from being directly configurable to avoid style prop conflicts
@@ -73,46 +49,35 @@ export const Button: FC<ComponentProps> = ({
   loading,
   color: componentColor,
   ...props
-}) =>
-  disabled ? (
-    <DisabledWrapper accessibilityLabel={accessibilityLabel} {...props}>
-      {loading ? <ActivityIndicator /> : <Label disabled>{label}</Label>}
-    </DisabledWrapper>
-  ) : (
-    <Wrapper
+}) => {
+  const ButtonContainer = disabled ? Container : Touchable;
+  const onPressAction = loading ? null : onPress;
+
+  return (
+    <ButtonContainer
+      centerContent
+      bg={disabled ? colors.disabled : backgroundColor}
+      borderRadius={40}
+      height={50}
+      width={0.6}
       accessibilityLabel={accessibilityLabel}
-      onPress={loading ? null : onPress}
-      bg={backgroundColor}
+      onPress={disabled ? null : onPressAction}
       {...props}
     >
-      {loading ? <ActivityIndicator /> : <Label color={componentColor}>{label}</Label>}
-    </Wrapper>
+      {loading ? (
+        <ActivityIndicator />
+      ) : (
+        <Text color={disabled ? colors.gray : componentColor} fontWeight="bold" fontSize={2}>
+          {label}
+        </Text>
+      )}
+    </ButtonContainer>
   );
-
-Wrapper.defaultProps = {
-  alignItems: 'center',
-  bg: colors.orange,
-  borderRadius: 40,
-  height: 50,
-  justifyContent: 'center',
-  width: 0.6,
-};
-
-DisabledWrapper.defaultProps = {
-  alignItems: 'center',
-  bg: colors.gray,
-  borderRadius: 40,
-  height: 50,
-  justifyContent: 'center',
-  width: 0.6,
-};
-
-Label.defaultProps = {
-  color: colors.white,
-  fontWeight: 'bold',
-  fontSize: 2,
 };
 
 Button.defaultProps = {
   disabled: false,
+  borderColor: colors.transparent,
+  borderWidth: 1,
+  backgroundColor: colors.orange,
 };

--- a/template/src/components/Button/index.ts
+++ b/template/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export * from './Button';

--- a/template/src/components/Login/Login.stories.tsx
+++ b/template/src/components/Login/Login.stories.tsx
@@ -1,0 +1,18 @@
+import { storiesOf } from '@storybook/react-native';
+import React from 'react';
+
+import { Login } from './Login';
+import { Screen } from '../Screen';
+import { colors } from '../../styles';
+
+const ScreenDecorator = storyFn => <Screen padding={10}>{storyFn()}</Screen>;
+
+storiesOf('components/Login', module)
+  .addDecorator(ScreenDecorator)
+  .add('Default', () => (
+    <Login
+      loginPress={() => console.log('login pressed')}
+      forgotPasswordPress={() => console.log('forgot password pressed')}
+      registrationPress={() => console.log('registration pressed')}
+    />
+  ));

--- a/template/src/components/Login/Login.tsx
+++ b/template/src/components/Login/Login.tsx
@@ -1,16 +1,10 @@
 import React, { FC } from 'react';
 import {
-  color,
-  space,
-  layout,
-  flexbox,
-  borders,
   BorderProps,
   ColorProps,
   SpaceProps,
   FlexProps,
 } from 'styled-system';
-import styled from '@emotion/native';
 import { Button } from '../Button';
 import { Text } from '../Text';
 import { TextInput } from '../TextInput';
@@ -18,8 +12,6 @@ import { Touchable } from '../Touchable';
 import { Container } from '../Container';
 
 import { colors } from '../../styles';
-import { Alert } from 'react-native';
-import { NavigationScreenProps } from 'react-navigation';
 
 interface LoginProps {
   /** the callbacks to be invoked onPress */
@@ -30,13 +22,6 @@ interface LoginProps {
 
 type ComponentProps = LoginProps & FlexProps & SpaceProps & BorderProps & ColorProps;
 
-const Divider = styled(Container)`
-  ${color}
-  ${borders}
-  ${space}
-  ${layout}
-  ${flexbox}
-`;
 export const Login: FC<ComponentProps> = ({
   loginPress,
   registrationPress,
@@ -97,11 +82,11 @@ export const Login: FC<ComponentProps> = ({
         }}
       />
 
-      <Divider flexDirection={'row'} marginTop={20}>
+      <Container flexDirection={'row'} marginTop={20}>
         <Container top={-9} flex={1} borderBottomWidth={1} borderBottomColor={colors.gray} />
         <Text color={colors.gray}>&nbsp; or &nbsp;</Text>
         <Container top={-9} flex={1} borderBottomWidth={1} borderBottomColor={colors.gray} />
-      </Divider>
+      </Container>
       <Button
         width={'100%'}
         marginTop={20}

--- a/template/src/components/Login/Login.tsx
+++ b/template/src/components/Login/Login.tsx
@@ -1,0 +1,127 @@
+import React, { FC } from 'react';
+import {
+  color,
+  space,
+  layout,
+  flexbox,
+  borders,
+  BorderProps,
+  ColorProps,
+  SpaceProps,
+  FlexProps,
+} from 'styled-system';
+import styled from '@emotion/native';
+import { Button } from '../Button';
+import { Text } from '../Text';
+import { TextInput } from '../TextInput';
+import { Touchable } from '../Touchable';
+import { Container } from '../Container';
+
+import { colors } from '../../styles';
+import { Alert } from 'react-native';
+import { NavigationScreenProps } from 'react-navigation';
+
+interface LoginProps {
+  /** the callbacks to be invoked onPress */
+  loginPress: () => void;
+  registrationPress: () => void;
+  forgotPasswordPress: () => void;
+}
+
+type ComponentProps = LoginProps & FlexProps & SpaceProps & BorderProps & ColorProps;
+
+const Divider = styled(Container)`
+  ${color}
+  ${borders}
+  ${space}
+  ${layout}
+  ${flexbox}
+`;
+export const Login: FC<ComponentProps> = ({
+  loginPress,
+  registrationPress,
+  forgotPasswordPress,
+  children,
+  ...props
+}) => {
+  return (
+    <Container
+      bg={colors.bgGray}
+      borderRadius={20}
+      height={'85%'}
+      marginBottom={'5%'}
+      centerContent
+      elevation={4}
+      overflow="visible"
+      padding={4}
+      shadowColor={colors.gray}
+      shadowOffset={{ width: 0, height: 0 }}
+      shadowOpacity={0.15}
+      shadowRadius={5}
+      {...props}
+    >
+      <Text fontSize={32} fontWeight={'bold'} marginBottom={'10%'} marginTop={'10%'}>
+        Welcome, please sign in.
+      </Text>
+      <TextInput
+        placeholder="✉️ User name"
+        marginTop={2}
+        borderRadius={5}
+        borderColor={colors.lightGray}
+      />
+      <TextInput
+        placeholder="🔑 Password"
+        marginTop={2}
+        borderRadius={5}
+        borderColor={colors.lightGray}
+      />
+      <Touchable
+        onPress={() => {
+          forgotPasswordPress();
+        }}
+        fullWidth
+        alignItems={'flex-end'}
+      >
+        <Text fontSize={1} marginTop={2} color={colors.blue}>
+          Forgot Password?
+        </Text>
+      </Touchable>
+      <Button
+        width={'100%'}
+        marginTop={40}
+        label="Login"
+        color={colors.white}
+        borderRadius={5}
+        onPress={() => {
+          loginPress();
+        }}
+      />
+
+      <Divider flexDirection={'row'} marginTop={20}>
+        <Container top={-9} flex={1} borderBottomWidth={1} borderBottomColor={colors.gray} />
+        <Text color={colors.gray}>&nbsp; or &nbsp;</Text>
+        <Container top={-9} flex={1} borderBottomWidth={1} borderBottomColor={colors.gray} />
+      </Divider>
+      <Button
+        width={'100%'}
+        marginTop={20}
+        label={'Create Account'}
+        borderRadius={5}
+        bg={colors.white}
+        color={colors.gray}
+        borderColor={colors.lightGray}
+        elevation={6}
+        borderWidth={1}
+        onPress={() => {
+          registrationPress();
+        }}
+      />
+    </Container>
+  );
+};
+
+Login.defaultProps = {
+  loginPress: console.log('implement login press'),
+  forgotPasswordPress: console.log('implement forgot password press'),
+  registrationPress: console.log('implement registration press'),
+};

--- a/template/src/components/Login/Login.tsx
+++ b/template/src/components/Login/Login.tsx
@@ -61,7 +61,7 @@ export const Login: FC<ComponentProps> = ({
       {...props}
     >
       <Text fontSize={32} fontWeight={'bold'} marginBottom={'10%'} marginTop={'10%'}>
-      Welcome, please {'\n'}sign in.
+        Welcome, please {'\n'}sign in.
       </Text>
       <TextInput
         placeholder="✉️ User name"
@@ -107,7 +107,7 @@ export const Login: FC<ComponentProps> = ({
         marginTop={20}
         label={'Create Account'}
         borderRadius={5}
-        bg={colors.white}
+        backgroundColor={colors.white}
         color={colors.gray}
         borderColor={colors.lightGray}
         elevation={6}

--- a/template/src/components/Login/Login.tsx
+++ b/template/src/components/Login/Login.tsx
@@ -61,7 +61,7 @@ export const Login: FC<ComponentProps> = ({
       {...props}
     >
       <Text fontSize={32} fontWeight={'bold'} marginBottom={'10%'} marginTop={'10%'}>
-        Welcome, please sign in.
+      Welcome, please {'\n'}sign in.
       </Text>
       <TextInput
         placeholder="✉️ User name"

--- a/template/src/components/Login/index.ts
+++ b/template/src/components/Login/index.ts
@@ -1,0 +1,1 @@
+export * from './Login';

--- a/template/src/components/TextInput/TextInput.stories.tsx
+++ b/template/src/components/TextInput/TextInput.stories.tsx
@@ -1,0 +1,6 @@
+import { storiesOf } from '@storybook/react-native';
+import React from 'react';
+
+import { TextInput } from './TextInput';
+
+storiesOf('components/TextInput', module).add('Default', () => <TextInput />);

--- a/template/src/components/TextInput/TextInput.tsx
+++ b/template/src/components/TextInput/TextInput.tsx
@@ -44,7 +44,7 @@ const Wrapper = styled(Container)`
     `}
 `;
 
-const TopLabel = styled(Text)``;
+
 
 const Input = styled.TextInput`
   ${flex};
@@ -59,7 +59,7 @@ const Input = styled.TextInput`
 // NOTE: for layout and dimensioning of TextInput, wrap it in a Container
 export const TextInput: FC<ComponentProps> = ({ topLabel, multiline, ...inputProps }) => (
   <Container fill={multiline} fullWidth>
-    {topLabel ? <TopLabel>{topLabel}</TopLabel> : null}
+    {topLabel ? <Text color={colors.gray} fontSize={2} marginVertical={0.5}>{topLabel}</Text> : null}
     <Input
       autoCapitalize="none"
       underlineColorAndroid={colors.transparent}
@@ -67,20 +67,9 @@ export const TextInput: FC<ComponentProps> = ({ topLabel, multiline, ...inputPro
       multiline={multiline}
       {...inputProps}
     />
-  </Wrapper>
+  </Container>
 );
 
-// grow to the full width of its parent container
-Wrapper.defaultProps = {
-  width: '100%',
-  grow: false,
-};
-
-TopLabel.defaultProps = {
-  color: colors.gray,
-  fontSize: 2,
-  my: 0.5,
-};
 
 TextInput.defaultProps = {
   bg: colors.white,

--- a/template/src/components/TextInput/TextInput.tsx
+++ b/template/src/components/TextInput/TextInput.tsx
@@ -36,16 +36,6 @@ type ComponentProps = TextInputProps &
   LayoutProps &
   FlexProps;
 
-const Wrapper = styled(Container)`
-  ${props =>
-    props.grow &&
-    `
-      flex: 1;
-    `}
-`;
-
-
-
 const Input = styled.TextInput`
   ${flex};
   ${borders};

--- a/template/src/components/TextInput/TextInput.tsx
+++ b/template/src/components/TextInput/TextInput.tsx
@@ -58,7 +58,7 @@ const Input = styled.TextInput`
 
 // NOTE: for layout and dimensioning of TextInput, wrap it in a Container
 export const TextInput: FC<ComponentProps> = ({ topLabel, multiline, ...inputProps }) => (
-  <Wrapper grow={multiline}>
+  <Container fill={multiline} fullWidth>
     {topLabel ? <TopLabel>{topLabel}</TopLabel> : null}
     <Input
       autoCapitalize="none"

--- a/template/src/components/TextInput/TextInput.tsx
+++ b/template/src/components/TextInput/TextInput.tsx
@@ -1,0 +1,93 @@
+import React, { FC } from 'react';
+import { TextInputProps as TextInputBaseProps } from 'react-native';
+import styled from '@emotion/native';
+import {
+  borders,
+  color,
+  layout,
+  space,
+  flex,
+  typography,
+  textStyle,
+  BorderProps,
+  FlexProps,
+  ColorProps,
+  LayoutProps,
+  SpaceProps,
+  TextStyleProps,
+  TypographyProps,
+} from 'styled-system';
+
+import { Container } from '../Container';
+import { Text } from '../Text';
+import { colors } from '../../styles';
+
+interface TextInputProps extends TextInputBaseProps {
+  /** An optional header label to render about the input */
+  topLabel?: string;
+}
+
+type ComponentProps = TextInputProps &
+  ColorProps &
+  SpaceProps &
+  TextStyleProps &
+  TypographyProps &
+  BorderProps &
+  LayoutProps &
+  FlexProps;
+
+const Wrapper = styled(Container)`
+  ${props =>
+    props.grow &&
+    `
+      flex: 1;
+    `}
+`;
+
+const TopLabel = styled(Text)``;
+
+const Input = styled.TextInput`
+  ${flex};
+  ${borders};
+  ${color};
+  ${layout};
+  ${space};
+  ${textStyle};
+  ${typography};
+`;
+
+// NOTE: for layout and dimensioning of TextInput, wrap it in a Container
+export const TextInput: FC<ComponentProps> = ({ topLabel, multiline, ...inputProps }) => (
+  <Wrapper grow={multiline}>
+    {topLabel ? <TopLabel>{topLabel}</TopLabel> : null}
+    <Input
+      autoCapitalize="none"
+      underlineColorAndroid={colors.transparent}
+      selectionColor={colors.primary}
+      multiline={multiline}
+      {...inputProps}
+    />
+  </Wrapper>
+);
+
+// grow to the full width of its parent container
+Wrapper.defaultProps = {
+  width: '100%',
+  grow: false,
+};
+
+TopLabel.defaultProps = {
+  color: colors.gray,
+  fontSize: 2,
+  my: 0.5,
+};
+
+TextInput.defaultProps = {
+  bg: colors.white,
+  borderWidth: 1,
+  borderColor: colors.black,
+  minHeight: 40,
+  p: 2,
+  textAlignVertical: 'center',
+  width: '100%',
+};

--- a/template/src/components/TextInput/index.ts
+++ b/template/src/components/TextInput/index.ts
@@ -1,0 +1,1 @@
+export * from './TextInput';

--- a/template/src/screens/IntroScreen/IntroScreen.tsx
+++ b/template/src/screens/IntroScreen/IntroScreen.tsx
@@ -3,6 +3,7 @@ import { ImageBackground, StatusBar, StyleSheet } from 'react-native';
 import { NavigationScreenProps } from 'react-navigation';
 import styled from '@emotion/native';
 
+import { Button } from '../../components/Button';
 import { Screen } from '../../components/Screen';
 import { Text } from '../../components/Text';
 import { Container } from '../../components/Container';
@@ -25,6 +26,7 @@ export function IntroScreen(props: NavigationScreenProps) {
           <Text testID="introScreenText" fontSize={5} color={colors.white}>
             Welcome to the intro Screen!
           </Text>
+          <Button label="Login" backgroundColor={colors.primary} onPress={() => props.navigation.navigate('Login')} borderRadius={5}/>
         </Container>
       </Screen>
     </BackgroundImage>

--- a/template/src/screens/IntroScreen/IntroScreen.tsx
+++ b/template/src/screens/IntroScreen/IntroScreen.tsx
@@ -26,7 +26,13 @@ export function IntroScreen(props: NavigationScreenProps) {
           <Text testID="introScreenText" fontSize={5} color={colors.white}>
             Welcome to the intro Screen!
           </Text>
-          <Button label="Login" backgroundColor={colors.primary} onPress={() => props.navigation.navigate('Login')} borderRadius={5}/>
+          <Button
+            label="Login"
+            backgroundColor={colors.primary}
+            color={colors.white}
+            onPress={() => props.navigation.navigate('Login')}
+            borderRadius={5}
+          />
         </Container>
       </Screen>
     </BackgroundImage>

--- a/template/src/screens/LoginScreen/LoginScreen.tsx
+++ b/template/src/screens/LoginScreen/LoginScreen.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Alert, ImageBackground, SafeAreaView, StatusBar, StyleSheet } from 'react-native';
+import { Alert, ImageBackground, StatusBar, StyleSheet } from 'react-native';
 import { NavigationScreenProps } from 'react-navigation';
 import styled from '@emotion/native';
 
 import { Login } from '../../components/Login';
+import { Screen } from '../../components/Screen';
 import bgImage from '../../assets/images/background.png';
+import { colors } from '../../styles';
 
 const BackgroundImage = styled(ImageBackground)`
   ${StyleSheet.absoluteFillObject};
@@ -24,25 +26,19 @@ export function LoginScreen(props: NavigationScreenProps) {
 
   return (
     <BackgroundImage source={bgImage} resizeMode="cover">
-      <SafeAreaView
-        style={{
-          flex: 1,
-          justifyContent: 'flex-end',
-          margin: 20,
-        }}
-      >
         <StatusBar
           translucent
           animated
           backgroundColor="rgba(0, 0, 0, 0.20)"
           barStyle="light-content"
         />
+        <Screen backgroundColor={colors.transparent} paddingTop={60} margin={20}>
         <Login
           loginPress={loginClick}
           registrationPress={registrationClick}
           forgotPasswordPress={forgotPwdClick}
         />
-      </SafeAreaView>
+      </Screen>
     </BackgroundImage>
   );
 }

--- a/template/src/screens/LoginScreen/LoginScreen.tsx
+++ b/template/src/screens/LoginScreen/LoginScreen.tsx
@@ -20,6 +20,7 @@ export function LoginScreen(props: NavigationScreenProps) {
   const registrationClick = () => {
     props.navigation.navigate('Registration');
   };
+  
   const forgotPwdClick = () => {
     Alert.alert('Forgot Pwd Clicked!', 'Further implement screen');
   };

--- a/template/src/screens/LoginScreen/LoginScreen.tsx
+++ b/template/src/screens/LoginScreen/LoginScreen.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { ImageBackground, StatusBar, StyleSheet } from 'react-native';
+import { Alert, ImageBackground, SafeAreaView, StatusBar, StyleSheet } from 'react-native';
 import { NavigationScreenProps } from 'react-navigation';
 import styled from '@emotion/native';
 
-import { Text } from '../../components/Text';
+import { Login } from '../../components/Login';
 import bgImage from '../../assets/images/background.png';
 
 const BackgroundImage = styled(ImageBackground)`
@@ -11,15 +11,38 @@ const BackgroundImage = styled(ImageBackground)`
 `;
 
 export function LoginScreen(props: NavigationScreenProps) {
+  const loginClick = () => {
+    props.navigation.navigate('Intro');
+  };
+
+  const registrationClick = () => {
+    props.navigation.navigate('Registration');
+  };
+  const forgotPwdClick = () => {
+    Alert.alert('Forgot Pwd Clicked!', 'Further implement screen');
+  };
+
   return (
     <BackgroundImage source={bgImage} resizeMode="cover">
-      <StatusBar
-        translucent
-        animated
-        backgroundColor="rgba(0, 0, 0, 0.20)"
-        barStyle="light-content"
-      />
-      <Text testID="introScreenText">Intro Screen!</Text>
+      <SafeAreaView
+        style={{
+          flex: 1,
+          justifyContent: 'flex-end',
+          margin: 20,
+        }}
+      >
+        <StatusBar
+          translucent
+          animated
+          backgroundColor="rgba(0, 0, 0, 0.20)"
+          barStyle="light-content"
+        />
+        <Login
+          loginPress={loginClick}
+          registrationPress={registrationClick}
+          forgotPasswordPress={forgotPwdClick}
+        />
+      </SafeAreaView>
     </BackgroundImage>
   );
 }

--- a/template/src/screens/LoginScreen/LoginScreen.tsx
+++ b/template/src/screens/LoginScreen/LoginScreen.tsx
@@ -26,13 +26,13 @@ export function LoginScreen(props: NavigationScreenProps) {
 
   return (
     <BackgroundImage source={bgImage} resizeMode="cover">
-        <StatusBar
-          translucent
-          animated
-          backgroundColor="rgba(0, 0, 0, 0.20)"
-          barStyle="light-content"
-        />
-        <Screen backgroundColor={colors.transparent} paddingTop={60} margin={20}>
+      <StatusBar
+        translucent
+        animated
+        backgroundColor="rgba(0, 0, 0, 0.20)"
+        barStyle="light-content"
+      />
+      <Screen backgroundColor={colors.transparent} paddingTop={60} margin={20}>
         <Login
           loginPress={loginClick}
           registrationPress={registrationClick}

--- a/template/src/styles/colors.ts
+++ b/template/src/styles/colors.ts
@@ -12,6 +12,7 @@ export const colors = {
   black,
   blue,
   bgGray,
+  disabled: gray,
   gray,
   grayText,
   lightGray,

--- a/template/src/styles/colors.ts
+++ b/template/src/styles/colors.ts
@@ -1,17 +1,21 @@
 const black = '#000';
 const blue = '#267FA1';
+const bgGray = '#F9F9F9';
 const gray = '#C4C4C4';
 const grayText = '#3f3f3f';
 const lightGray = '#E4E4E4';
+const orange = '#FF8C53';
 const transparent = 'rgba(0, 0, 0, 0)';
 const white = '#fff';
 
 export const colors = {
   black,
   blue,
+  bgGray,
   gray,
   grayText,
   lightGray,
+  orange,
   primary: blue,
   transparent,
   white,

--- a/template/storybook/stories/index.ts
+++ b/template/storybook/stories/index.ts
@@ -1,4 +1,7 @@
+import '../../src/components/Button/Button.stories';
 import '../../src/components/Container/Container.stories';
 import '../../src/components/Screen/Screen.stories';
 import '../../src/components/Text/Text.stories';
+import '../../src/components/TextInput/TextInput.stories';
 import '../../src/components/Touchable/Touchable.stories';
+import '../../src/components/Login/Login.stories';


### PR DESCRIPTION
*  Base Login component added, updated Login Screen to reference 
*  Added TextInput and Button Primatives as styled components
(still needs work to implement the icon with the textInput)
*  Updated component.ejs to use container instead of the old view

Expect to be able to Navigate to Login Screen From Intro and then see new Login Component with some placeholder navigation events
![Screen Shot 2019-11-06 at 11 43 47 AM](https://user-images.githubusercontent.com/7119624/68332247-47022b00-008b-11ea-9590-32262124f0f7.png)
