### PR TITLE
feat(solidarity): Ensure local version of RN cli

### DIFF
--- a/template/.solidarity
+++ b/template/.solidarity
@@ -67,17 +67,11 @@
       }
     ],
     "React Native": [
-      {
-        "rule": "cli",
-        "binary": "react-native",
-        "semver": ">=2.0.1"
-      },
-      {
-        "rule": "cli",
-        "binary": "react-native",
-        "semver": "^0.61.1",
-        "line": 2,
-        "error": "react-native@{{wantedVersion}} is required (you have {{installedVersion}}). Check your `package.json` and run `yarn install`."
+     {
+        "rule": "shell",
+        "command": "which react-native",
+        "match": "node_modules/.bin/react-native",
+        "error": "It looks like you have react-native-cli installed globally. Use 'yarn global remove react-native' or 'npm uninstall -g react-native'. See: 'https://github.com/react-native-community/cli#about'"
       }
     ],
     "Detox": [


### PR DESCRIPTION
This updates the RN cli check to look for a local version using "which react-native". If `which react-native` does not return `node_modules/.bin/react-native` we assume global.

See screenshots for examples of pass/fail.

<img width="1434" alt="global-rn-error" src="https://user-images.githubusercontent.com/14339/68607141-f2d9bb00-047d-11ea-96d8-a09dafc07464.png">

<img width="763" alt="check-global-rn" src="https://user-images.githubusercontent.com/14339/68607147-f53c1500-047d-11ea-9f3f-e5e2e1aa1d03.png">


Fixes #94 