### PR TITLE
chore(solidarity): Update applesimutils error message

### DIFF
--- a/template/.solidarity
+++ b/template/.solidarity
@@ -79,7 +79,7 @@
         "rule": "cli",
         "binary": "applesimutils",
         "semver": ">=0.7.4",
-        "error": "Use --fix. To upgrade, use 'brew upgrade applesimutils'. If you get errors, try 'brew untap wix/brew && brew tap wix/brew'",
+        "error": "To install, use 'yarn solidarity --fix'. To upgrade, use 'brew upgrade applesimutils'. If you get errors, try 'brew untap wix/brew && brew tap wix/brew'",
         "fix": "brew tap wix/brew && brew install applesimutils"
       }
     ],

--- a/template/.solidarity
+++ b/template/.solidarity
@@ -79,6 +79,7 @@
         "rule": "cli",
         "binary": "applesimutils",
         "semver": ">=0.7.4",
+        "error": "Use --fix. To upgrade, use 'brew upgrade applesimutils'. If you get errors, try 'brew untap wix/brew && brew tap wix/brew'",
         "fix": "brew tap wix/brew && brew install applesimutils"
       }
     ],

--- a/template/.solidarity
+++ b/template/.solidarity
@@ -67,17 +67,11 @@
       }
     ],
     "React Native": [
-      {
-        "rule": "cli",
-        "binary": "react-native",
-        "semver": ">=2.0.1"
-      },
-      {
-        "rule": "cli",
-        "binary": "react-native",
-        "semver": "^0.61.1",
-        "line": 2,
-        "error": "react-native@{{wantedVersion}} is required (you have {{installedVersion}}). Check your `package.json` and run `yarn install`."
+     {
+        "rule": "shell",
+        "command": "which react-native",
+        "match": "node_modules/.bin/react-native",
+        "error": "It looks like you have react-native-cli installed globally. Use 'yarn global remove react-native' or 'npm uninstall -g react-native'. See: 'https://github.com/react-native-community/cli#about'"
       }
     ],
     "Detox": [


### PR DESCRIPTION
`--fix` works if the user doesn't have it installed, but not for upgrading. This updates the error message to reflect both.

Screenshot:
<img width="1426" alt="detox error message" src="https://user-images.githubusercontent.com/14339/68609808-536bf680-0484-11ea-8688-98efb6260db6.png">
