### PR TITLE
fix(dependencies): adds missing eslint-plugin-import dependency

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -62,6 +62,7 @@
     "babel-jest": "^24.9.0",
     "eslint": "^6.4.0",
     "eslint-plugin-echobind": "^0.1.0",
+    "eslint-plugin-import": "^2.18.2",
     "solidarity": "^2.3.1"
   },
   "jest": {


### PR DESCRIPTION
`eslint-plugin-import` is specified in the eslint config, however not in the dependencies.
This PR adds it as a dev dependency. (Necessary for VS Code eslint to work)