### PR TITLE
feat: Default gitignore file

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,0 +1,67 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+.project
+android/.settings/
+android/app/.settings
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+!debug.keystore
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/
+
+*/fastlane/report.xml
+*/fastlane/Preview.html
+*/fastlane/screenshots
+.env
+.env.*
+!.env.example
+
+
+# Bundle artifact
+*.jsbundle
+
+# CocoaPods
+/ios/Pods/
+*dSYM.zip


### PR DESCRIPTION
Adds a default `.gitignore` file so that on initial check-in you don't accidentally check in node_modules and other files.

Fixes issue #126 