### PR TITLE
chore: Start Script & Fix Display Name

### DIFF
--- a/template/ios/HelloWorld/Info.plist
+++ b/template/ios/HelloWorld/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Hello App Display Name</string>
+	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,9 @@
   "description": "a React Native app bootstrapped with the Echobind template",
   "private": true,
   "scripts": {
+    "start": "react-native start --reset-cache",
     "test": "jest",
+    "test:ci": "jest", 
     "test:watch": "jest --changedSince=master --watch",
     "lint": "eslint . --ext .ts,.tsx",
     "g:component": "hygen component new --name",

--- a/template/package.json
+++ b/template/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@storybook/addon-ondevice-backgrounds": "^5.2.5",
     "@storybook/addons": "^5.2.5",
-    "@storybook/react-native": "^5.2.5",
+    "@storybook/react-native": "^5.3.0-rc.1",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.7",
     "@types/react": "^16.9.0",


### PR DESCRIPTION
Adds the start script back to the package json with reset cache parameter

Update Storybook to resolve async storage warning

Update info.plist to resolve the app display name to match project name



issue #116  start script
issue #121 async storage warning
issue #131 iOS display name
