### PR TITLE
feat: Update solidarity bundler check

### DIFF
--- a/template/.solidarity
+++ b/template/.solidarity
@@ -26,6 +26,8 @@
       {
         "rule": "cli",
         "binary": "bundle",
+        "version": "version",
+        "semver": ">=2.0.2",
         "error": "Bundler is used to install RubyGems"
       },
       {

--- a/template/Gemfile.lock
+++ b/template/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
     emoji_regex (1.0.1)
-    excon (0.67.0)
+    excon (0.72.0)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)

--- a/template/src/utils/trimText/index.ts
+++ b/template/src/utils/trimText/index.ts
@@ -1,0 +1,1 @@
+export { default } from './trimText';

--- a/template/src/utils/trimText/trimText.test.ts
+++ b/template/src/utils/trimText/trimText.test.ts
@@ -1,0 +1,17 @@
+import { trimText } from './trimText';
+
+describe('trimText', () => {
+  test('should trim a long string to the alloted length', () => {
+    const longString = 'a'.repeat(100);
+    const newLength = 30;
+    const shortString = 'a'.repeat(newLength) + '...';
+
+    expect(trimText(longString, newLength)).toEqual(shortString);
+  });
+  test('should trim a long string to the default length', () => {
+    const longString = 'a'.repeat(100);
+    const shortString = 'a'.repeat(70) + '...';
+
+    expect(trimText(longString)).toEqual(shortString);
+  });
+});

--- a/template/src/utils/trimText/trimText.ts
+++ b/template/src/utils/trimText/trimText.ts
@@ -1,0 +1,10 @@
+const DEFAULT_MAX_LENGTH = 70;
+
+/**
+ * Function to trim a string to a specific length
+ * string - input string
+ * length - the length to trim the string to
+ */
+export function trimText(string: string, length: number = DEFAULT_MAX_LENGTH): string {
+  return `${string.substring(0, length)}...`;
+}


### PR DESCRIPTION
This adds a version check for bundler when running solidarity. Ensures it is min version of 2.0.2

This also adds a simple textTrim utility that has a test so that if you run `yarn test` it has a test it can run. This will be used for presentation purposes at Epic Conf